### PR TITLE
BlockCompressorStream#finish add check compressor.getBytesRead()>0

### DIFF
--- a/src/java/org/apache/hadoop/io/compress/BlockCompressorStream.java
+++ b/src/java/org/apache/hadoop/io/compress/BlockCompressorStream.java
@@ -133,7 +133,7 @@ public class BlockCompressorStream extends CompressorStream {
   }
 
   public void finish() throws IOException {
-    if (!compressor.finished()) {
+    if (!compressor.finished() && compressor.getBytesRead()>0) {
       rawWriteInt((int)compressor.getBytesRead());
       compressor.finish();
       while (!compressor.finished()) {


### PR DESCRIPTION
org.apache.hadoop.io.compress.BlockCompressorStream#finish is a public function,so other apps can call the method directly,such as `flume`,but when `compressor.getBytesRead() == 0` then it will write a null data,and then the data after the null data will not be read as they lost. So,please add the check in the method.
Thank you.
